### PR TITLE
Fixed for DTE removal

### DIFF
--- a/src/2022/ItemTemplates/ToolWindowCommunity/MyControl.xaml
+++ b/src/2022/ItemTemplates/ToolWindowCommunity/MyControl.xaml
@@ -10,12 +10,19 @@
              xmlns:toolkit="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
              toolkit:Themes.UseVsTheme="True"
              mc:Ignorable="d"
-             d:DesignHeight="300" d:DesignWidth="300"
+             d:DesignHeight="300"
+             d:DesignWidth="300"
              Name="MyToolWindow">
     <Grid>
         <StackPanel Orientation="Vertical">
-            <TextBlock Margin="10" HorizontalAlignment="Center">$safeitemname$</TextBlock>
-            <Button Content="Click me!" Click="button1_Click" Width="120" Height="80" Name="button1"/>
+            <Label x:Name="lblHeadline"
+                   Margin="10"
+                   HorizontalAlignment="Center" />
+            <Button Content="Click me!"
+                    Click="button1_Click"
+                    Width="120"
+                    Height="80"
+                    Name="button1" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/2022/ItemTemplates/ToolWindowCommunity/MyControl.xaml.cs
+++ b/src/2022/ItemTemplates/ToolWindowCommunity/MyControl.xaml.cs
@@ -1,19 +1,22 @@
-﻿using System.Windows;
+﻿using Community.VisualStudio.Toolkit;
+using System;
+using System.Windows;
 using System.Windows.Controls;
-using Community.VisualStudio.Toolkit;
 
 namespace $rootnamespace$
 {
     public partial class $safeitemname$ : UserControl
     {
-        public $safeitemname$()
+        public $safeitemname$(Version vsVersion)
         {
             InitializeComponent();
+
+            lblHeadline.Content = $"Visual Studio v{vsVersion}";
         }
 
         private void button1_Click(object sender, RoutedEventArgs e)
         {
-            VS.Notifications.ShowMessage("Button clicked");
+            VS.MessageBox.Show("$safeitemname$", "Button clicked");
         }
     }
 }

--- a/src/2022/ItemTemplates/ToolWindowCommunity/ToolWindow.cs
+++ b/src/2022/ItemTemplates/ToolWindowCommunity/ToolWindow.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using Microsoft.VisualStudio.Shell;
-using System.Windows;
-using Community.VisualStudio.Toolkit;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
+using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Imaging;
-using Task = System.Threading.Tasks.Task;
+using Microsoft.VisualStudio.Shell;
 
 namespace $rootnamespace$
 {
@@ -16,9 +15,10 @@ namespace $rootnamespace$
 
         public override Type PaneType => typeof(Pane);
 
-        public override Task<FrameworkElement> CreateAsync(int toolWindowId, CancellationToken cancellationToken)
+        public override async Task<FrameworkElement> CreateAsync(int toolWindowId, CancellationToken cancellationToken)
         {
-            return Task.FromResult<FrameworkElement>(new $safeitemname$Control());
+            Version vsVersion = await VS.Shell.GetVsVersionAsync();
+            return new $safeitemname$Control(vsVersion);
         }
 
         [Guid("$guid1$")]
@@ -26,7 +26,7 @@ namespace $rootnamespace$
         {
             public Pane()
             {
-                BitmapImageMoniker = KnownMonikers.StatusInformation;
+                BitmapImageMoniker = KnownMonikers.ToolWindow;
             }
         }
     }

--- a/src/2022/ProjectTemplates/VsixProjectWindow/ToolWindows/Control.xaml
+++ b/src/2022/ProjectTemplates/VsixProjectWindow/ToolWindows/Control.xaml
@@ -10,12 +10,19 @@
              xmlns:toolkit="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
              toolkit:Themes.UseVsTheme="True"
              mc:Ignorable="d"
-             d:DesignHeight="300" d:DesignWidth="300"
+             d:DesignHeight="300"
+             d:DesignWidth="300"
              Name="MyToolWindow">
     <Grid>
         <StackPanel Orientation="Vertical">
-            <Label x:Name="lblHeadline" Margin="10" HorizontalAlignment="Center">Click me!!</Label>
-            <Button Content="Click me!" Click="button1_Click" Width="120" Height="80" Name="button1"/>
+            <Label x:Name="lblHeadline"
+                   Margin="10"
+                   HorizontalAlignment="Center" />
+            <Button Content="Click me!"
+                    Click="button1_Click"
+                    Width="120"
+                    Height="80"
+                    Name="button1" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/2022/ProjectTemplates/VsixProjectWindow/ToolWindows/Control.xaml.cs
+++ b/src/2022/ProjectTemplates/VsixProjectWindow/ToolWindows/Control.xaml.cs
@@ -1,21 +1,22 @@
-﻿using System.Windows;
+﻿using Community.VisualStudio.Toolkit;
+using System;
+using System.Windows;
 using System.Windows.Controls;
-using Community.VisualStudio.Toolkit;
 
 namespace $safeprojectname$
 {
     public partial class MyToolWindowControl : UserControl
     {
-        public MyToolWindowControl(EnvDTE80.DTE2 dte)
+        public MyToolWindowControl(Version vsVersion)
         {
             InitializeComponent();
 
-            lblHeadline.Content = $"Visual Studio v{dte.Version}";
+            lblHeadline.Content = $"Visual Studio v{vsVersion}";
         }
 
         private void button1_Click(object sender, RoutedEventArgs e)
         {
-            VS.Notifications.ShowMessage("$safeprojectname$", "Button clicked");
+            VS.MessageBox.Show("$safeprojectname$", "Button clicked");
         }
     }
 }

--- a/src/2022/ProjectTemplates/VsixProjectWindow/ToolWindows/ToolWindow.cs
+++ b/src/2022/ProjectTemplates/VsixProjectWindow/ToolWindows/ToolWindow.cs
@@ -12,12 +12,13 @@ namespace $safeprojectname$
     public class MyToolWindow : BaseToolWindow<MyToolWindow>
     {
         public override string GetTitle(int toolWindowId) => "My Tool Window";
+        
         public override Type PaneType => typeof(Pane);
 
         public override async Task<FrameworkElement> CreateAsync(int toolWindowId, CancellationToken cancellationToken)
         {
-            EnvDTE80.DTE2 dte = await VS.GetDTEAsync();
-            return new MyToolWindowControl(dte);
+            Version vsVersion = await VS.Shell.GetVsVersionAsync();
+            return new MyToolWindowControl(vsVersion);
         }
 
         [Guid("$guid5$")]


### PR DESCRIPTION
VSIX project and item templates for Tool Window appeared to break after removing DTE from toolkit.  This only focused on 2022 project as 2019 still generates the DTE code.  I didn't attempt this as I recall hearing there are some difference between versions when working with the Tool Windows.  2019 can be fixed in future PR.