### PR TITLE
Marked DialogPage derived classes with ComVisible(true)

### DIFF
--- a/src/2019/ItemTemplates/OptionsPageCommunity/OptionsPage.cs
+++ b/src/2019/ItemTemplates/OptionsPageCommunity/OptionsPage.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
 using Community.VisualStudio.Toolkit;
 
 namespace $rootnamespace$
@@ -8,6 +9,7 @@ namespace $rootnamespace$
         // Register the options with these attributes on your package class:
         // [ProvideOptionPage(typeof(OptionsProvider.$safeitemname$Options), "$rootnamespace$", "$safeitemname$", 0, 0, true)]
         // [ProvideProfile(typeof(OptionsProvider.$safeitemname$Options), "$rootnamespace$", "$safeitemname$", 0, 0, true)]
+        [ComVisible(true)]
         public class $safeitemname$Options : BaseOptionPage<$safeitemname$> { }
     }
 

--- a/src/2022/ItemTemplates/OptionsPageCommunity/OptionsPage.cs
+++ b/src/2022/ItemTemplates/OptionsPageCommunity/OptionsPage.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Runtime.InteropServices;
 
 namespace $rootnamespace$
 {
@@ -7,6 +8,7 @@ namespace $rootnamespace$
         // Register the options with these attributes on your package class:
         // [ProvideOptionPage(typeof(OptionsProvider.$safeitemname$Options), "$rootnamespace$", "$safeitemname$", 0, 0, true)]
         // [ProvideProfile(typeof(OptionsProvider.$safeitemname$Options), "$rootnamespace$", "$safeitemname$", 0, 0, true)]
+        [ComVisible(true)]
         public class $safeitemname$Options : BaseOptionPage<$safeitemname$> { }
     }
 


### PR DESCRIPTION
Related to https://github.com/VsixCommunity/Community.VisualStudio.Toolkit/pull/244

Classes inheriting from `DialogPage` should be marked as `ComVisible` so that they can support profiles.